### PR TITLE
feat: harden default group additing

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -12,6 +12,7 @@
 namespace FoF\DefaultGroup;
 
 use Flarum\Extend;
+use Flarum\Group\Event\Deleted;
 use Flarum\Group\Group;
 use Flarum\User\Event\Activated;
 
@@ -23,7 +24,8 @@ return [
     new Extend\Locales(__DIR__.'/resources/locale'),
 
     (new Extend\Event())
-        ->listen(Activated::class, Listeners\AddDefaultGroup::class),
+        ->listen(Activated::class, Listeners\AddDefaultGroup::class)
+        ->listen(Deleted::class, Listeners\GroupDeleted::class),
 
     (new Extend\Settings())
         ->default('fof-default-group.group', Group::MEMBER_ID),

--- a/src/Listeners/AddDefaultGroup.php
+++ b/src/Listeners/AddDefaultGroup.php
@@ -32,10 +32,20 @@ class AddDefaultGroup
 
     public function handle(Activated $event)
     {
-        $defaultGroup = Group::findOrFail($this->settings->get('fof-default-group.group'));
+        $defaultGroupId = $this->settings->get('fof-default-group.group');
 
-        if ($defaultGroup !== null && $defaultGroup->id !== Group::MEMBER_ID && !$event->user->groups->contains($defaultGroup)) {
-            $event->user->groups()->attach($defaultGroup->id);
+        if (! $defaultGroupId || $defaultGroupId === Group::MEMBER_ID) {
+            return;
+        }
+
+        $defaultGroup = Group::find($defaultGroupId);
+
+        if (! $defaultGroup) {
+            return;
+        }
+
+        if (! $event->users->groups->contains($defaultGroup)) {
+            $event->user->groups()->attach($defaultGroupId);
         }
     }
 }

--- a/src/Listeners/GroupDeleted.php
+++ b/src/Listeners/GroupDeleted.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace FoF\DefaultGroup\Listeners;
+
+use Flarum\Group\Event\Deleted;
+use Flarum\Settings\SettingsRepositoryInterface;
+
+class GroupDeleted
+{
+    /**
+     * @var SettingsRepositoryInterface
+     */
+    protected $settings;
+
+    /**
+     * @param SettingsRepositoryInterface $settings
+     */
+    public function __construct(SettingsRepositoryInterface $settings)
+    {
+        $this->settings = $settings;
+    }
+
+    public function handle(Deleted $event)
+    {
+        $defaultGroupId = $this->settings->get('fof-default-group.group');
+
+        if ($defaultGroupId === $event->group->id) {
+            $this->settings->set('fof-default-group.group', null);
+        }
+    }
+}


### PR DESCRIPTION
- removes default group in case group is deleted
- stops throwing mystifying 404 when group doesn't exist

---

Was debugging this on our hosted platform after an admin had deleted the group assigned to the Default Group. This causes every registration to fail with a "resource not found". As this also does not have any trace, it's extremely hard to identify the underlying issue.